### PR TITLE
Add argument validation for difftw wrapper

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,56 @@ use std::env;
 use std::io::{self, BufRead, BufReader, Write};
 use std::process::{Command, Stdio, exit};
 
+/// Search for a flag within the argument list. Returns `None` if the flag is not
+/// present. Returns `Some(Some(value))` if the flag is present with a value and
+/// `Some(None)` if the flag is present but no value follows.
+fn find_flag_value(args: &[String], flag: &str) -> Option<Option<String>> {
+    for i in 0..args.len() {
+        if args[i] == flag {
+            return Some(args.get(i + 1).cloned());
+        }
+
+        let with_eq = format!("{}=", flag);
+        if let Some(v) = args[i].strip_prefix(&with_eq) {
+            return Some(Some(v.to_string()));
+        }
+    }
+    None
+}
+
 fn main() -> io::Result<()> {
-    let args: Vec<String> = env::args().skip(1).collect();
+    // Collect all arguments provided to the wrapper except the binary name
+    let mut args: Vec<String> = env::args().skip(1).collect();
+
+    // Check the provided flags and ensure the required ones are present
+    let display_mode = find_flag_value(&args, "--display");
+    let color_mode = find_flag_value(&args, "--color");
+
+    if let Some(Some(d)) = &display_mode {
+        if d != "inline" {
+            eprintln!("difftw only supports --display=inline");
+            exit(1);
+        }
+    }
+
+    if let Some(Some(c)) = &color_mode {
+        if c != "always" {
+            eprintln!("difftw only supports --color=always");
+            exit(1);
+        }
+    }
+
+    // Prepend missing required flags
+    let mut prefix = Vec::new();
+    if display_mode.is_none() {
+        prefix.push("--display=inline".to_string());
+    }
+    if color_mode.is_none() {
+        prefix.push("--color=always".to_string());
+    }
+    if !prefix.is_empty() {
+        args.splice(0..0, prefix);
+    }
 
     let mut child = Command::new("difft")
         .args(&args)


### PR DESCRIPTION
## Summary
- ensure `--display=inline` and `--color=always` are always passed
- exit with an error if incorrect values are supplied
- automatically add missing flags before invoking `difft`

## Testing
- `cargo build`
- `cargo test`
- `cargo fmt -- --check`


------
https://chatgpt.com/codex/tasks/task_e_6846b408bd388320979b07ef41b63cde