### PR TITLE
Add color stripping when output is not a terminal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.2.0"
 edition = "2024"
 
 [dependencies]
+atty = "0.2"
+strip-ansi-escapes = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,4 @@ version = "0.2.0"
 edition = "2024"
 
 [dependencies]
-atty = "0.2"
 strip-ansi-escapes = "0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
-use atty::Stream;
 use std::env;
-use std::io::{self, BufRead, BufReader, Write};
+use std::io::{self, BufRead, BufReader, IsTerminal, Write};
 use std::process::{Command, Stdio, exit};
 use strip_ansi_escapes::strip_str;
 
@@ -76,7 +75,7 @@ fn main() -> io::Result<()> {
 
     let reader = BufReader::new(stdout);
     let mut handle = io::stdout();
-    let strip_color = !atty::is(Stream::Stdout);
+    let strip_color = !std::io::stdout().is_terminal();
 
     for line_res in reader.lines() {
         let line = line_res?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
+use atty::Stream;
 use std::env;
 use std::io::{self, BufRead, BufReader, Write};
 use std::process::{Command, Stdio, exit};
+use strip_ansi_escapes::strip_str;
 
 const GRAY: &str = "\x1b[2m";
 const RED: &str = "\x1b[91;1m";
@@ -33,20 +35,26 @@ fn validate_and_add_flags(args: &mut Vec<String>) {
     }
 }
 
-fn process_line(line: &str, handle: &mut impl Write) -> io::Result<()> {
+fn process_line(line: &str, handle: &mut impl Write, strip_color: bool) -> io::Result<()> {
     let trimmed = line.trim_start();
     let indent_len = line.len() - trimmed.len();
     let indent = &line[..indent_len];
 
-    if trimmed.starts_with(GRAY) {
-        writeln!(handle, " {}", line)
+    let mut output = if trimmed.starts_with(GRAY) {
+        format!(" {}\n", line)
     } else if trimmed.starts_with(RED) {
-        write!(handle, "{}{}-{}\n", indent, RED, &trimmed[RED.len()..])
+        format!("{}{}-{}\n", indent, RED, &trimmed[RED.len()..])
     } else if trimmed.starts_with(GREEN) {
-        write!(handle, "{}+{}{}\n", GREEN, indent, &trimmed[GREEN.len()..])
+        format!("{}+{}{}\n", GREEN, indent, &trimmed[GREEN.len()..])
     } else {
-        writeln!(handle, "{}", line)
+        format!("{}\n", line)
+    };
+
+    if strip_color {
+        output = strip_str(&output);
     }
+
+    write!(handle, "{}", output)
 }
 
 fn main() -> io::Result<()> {
@@ -68,10 +76,11 @@ fn main() -> io::Result<()> {
 
     let reader = BufReader::new(stdout);
     let mut handle = io::stdout();
+    let strip_color = !atty::is(Stream::Stdout);
 
     for line_res in reader.lines() {
         let line = line_res?;
-        process_line(&line, &mut handle)?;
+        process_line(&line, &mut handle, strip_color)?;
     }
 
     let status = child.wait()?;


### PR DESCRIPTION
## Summary
- check if stdout is a tty
- use `strip-ansi-escapes` to remove color codes
- new dependencies: `atty` and `strip-ansi-escapes`

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68482948c71c8320b81c896ceb02d00d