### PR TITLE
Add configurable color output to difftw

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,24 @@ Simply use `difftw` as a drop-in replacement for `difft`:
 difftw file1.txt file2.txt
 ```
 
-The wrapper automatically adds the required `--display=inline --color=always` flags if they're not present. You can also specify them manually:
+The wrapper automatically adds the required `--display=inline` flag and forces
+`difft` to emit colors. You can control whether the wrapper itself outputs
+colors using the `--color` option (`always`, `auto`, or `never`) or the
+`DFT_COLOR` environment variable. When not specified, the default is `auto`.
+Examples:
 ```bash
-difftw --display=inline --color=always file1.txt file2.txt
+# Always show colors
+difftw --color=always file1.txt file2.txt
+
+# Disable colors
+difftw --color=never file1.txt file2.txt
+
+# Auto-detect based on stdout
+difftw file1.txt file2.txt
 ```
 
-**Note**: This tool only supports inline display mode and always-on colors. If you specify different values for these flags, the tool will exit with an error.
+**Note**: This tool only supports inline display mode. If you specify a
+different value for `--display`, the tool will exit with an error.
 
 For git integration:
 ```bash

--- a/README.md
+++ b/README.md
@@ -62,24 +62,28 @@ Simply use `difftw` as a drop-in replacement for `difft`:
 difftw file1.txt file2.txt
 ```
 
-The wrapper automatically adds the required `--display=inline` flag and forces
-`difft` to emit colors. You can control whether the wrapper itself outputs
-colors using the `--color` option (`always`, `auto`, or `never`) or the
-`DFT_COLOR` environment variable. When not specified, the default is `auto`.
+The wrapper automatically adds the `--display=inline` argument and forces `difft`
+to produce colorized output (`--color=always`) so that the wrapper can parse it.
+
+The decision to display colors in the final output follows the standard behavior
+of `difft` itself. You can control this with the `--color` option (`always`,
+`auto`, or `never`) or the `DFT_COLOR` environment variable. By default, the
+behavior is `auto` (i.e., colors are enabled when writing to a terminal).
+
 Examples:
 ```bash
-# Always show colors
+# Enable colors (default when writing to a terminal)
 difftw --color=always file1.txt file2.txt
 
 # Disable colors
 difftw --color=never file1.txt file2.txt
 
-# Auto-detect based on stdout
+# Auto-detect based on whether output is a terminal (default)
 difftw file1.txt file2.txt
 ```
 
-**Note**: This tool only supports inline display mode. If you specify a
-different value for `--display`, the tool will exit with an error.
+**Note**: This tool only supports inline display mode. If you specify a different
+value for `--display`, the tool will exit with an error.
 
 For git integration:
 ```bash

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,10 +7,9 @@ const GRAY: &str = "\x1b[2m";
 const RED: &str = "\x1b[91;1m";
 const GREEN: &str = "\x1b[92;1m";
 
-/// Validate `--display` and `--color` flags and insert defaults if missing.
+/// Validate `--display` flag and insert required defaults.
 fn validate_and_add_flags(args: &mut Vec<String>) {
     let has_display = args.iter().any(|a| a.starts_with("--display"));
-    let has_color = args.iter().any(|a| a.starts_with("--color"));
 
     if let Some(flag) = args.iter().find(|a| a.starts_with("--display=")) {
         if !flag.ends_with("inline") {
@@ -19,19 +18,50 @@ fn validate_and_add_flags(args: &mut Vec<String>) {
         }
     }
 
-    if let Some(flag) = args.iter().find(|a| a.starts_with("--color=")) {
-        if !flag.ends_with("always") {
-            eprintln!("difftw only supports --color=always");
-            exit(1);
-        }
-    }
-
     if !has_display {
         args.insert(0, "--display=inline".to_string());
     }
-    if !has_color {
-        args.insert(0, "--color=always".to_string());
+
+    // Force difft to always output colors so that our parser works correctly.
+    args.insert(0, "--color=always".to_string());
+}
+
+enum ColorSetting {
+    Auto,
+    Always,
+    Never,
+}
+
+/// Determine the desired output color setting for the wrapper.
+/// The `--color` command line argument has precedence over the `DFT_COLOR`
+/// environment variable. Allowed values are `always`, `auto` and `never`.
+fn parse_color_setting(args: &mut Vec<String>) -> ColorSetting {
+    if let Some(pos) = args.iter().position(|a| a.starts_with("--color=")) {
+        let arg = args.remove(pos);
+        return match &arg[8..] {
+            "always" => ColorSetting::Always,
+            "auto" => ColorSetting::Auto,
+            "never" => ColorSetting::Never,
+            other => {
+                eprintln!("Invalid value for --color: {}", other);
+                exit(1);
+            }
+        };
     }
+
+    if let Ok(var) = env::var("DFT_COLOR") {
+        return match var.as_str() {
+            "always" => ColorSetting::Always,
+            "auto" => ColorSetting::Auto,
+            "never" => ColorSetting::Never,
+            other => {
+                eprintln!("Invalid value for DFT_COLOR: {}", other);
+                exit(1);
+            }
+        };
+    }
+
+    ColorSetting::Auto
 }
 
 fn process_line(line: &str, handle: &mut impl Write, strip_color: bool) -> io::Result<()> {
@@ -60,6 +90,9 @@ fn main() -> io::Result<()> {
     // Collect all arguments provided to the wrapper except the binary name
     let mut args: Vec<String> = env::args().skip(1).collect();
 
+    // Determine wrapper color setting and remove the flag from difft args
+    let color_setting = parse_color_setting(&mut args);
+
     // Ensure required flags are valid and present
     validate_and_add_flags(&mut args);
 
@@ -75,7 +108,11 @@ fn main() -> io::Result<()> {
 
     let reader = BufReader::new(stdout);
     let mut handle = io::stdout();
-    let strip_color = !std::io::stdout().is_terminal();
+    let strip_color = match color_setting {
+        ColorSetting::Always => false,
+        ColorSetting::Never => true,
+        ColorSetting::Auto => !std::io::stdout().is_terminal(),
+    };
 
     for line_res in reader.lines() {
         let line = line_res?;


### PR DESCRIPTION
## Summary
- add `--color` wrapper option and `DFT_COLOR` env var
- force `difft` to always use color but respect wrapper color setting
- document new color behaviour in README

## Testing
- `cargo fmt -- --check`
- `cargo check`
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_684887a0d4408320a303bcd903e39921